### PR TITLE
Implemented check for insufficient funds in user wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * Fixed value of max allowance.
 
-### 1.0.3 (2020-07-28)
+### 1.0.3 (2020-08-05)
 
 ##### Features updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,9 @@
 ##### Features updated
 
 * Updated class and method export
+
+### 1.0.2 (2020-07-28)
+
+##### Features updated
+
+* Fixed value of max allowance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,9 @@
 ##### Features updated
 
 * Fixed value of max allowance.
+
+### 1.0.3 (2020-07-28)
+
+##### Features updated
+
+* Implemented a check for insufficient funds in user's wallet

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inbloxme/inblox-token-swaps",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Inblox Token Swap SDK",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inbloxme/inblox-token-swaps",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Inblox Token Swap SDK",
   "main": "src/index.js",
   "scripts": {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,4 +6,5 @@ module.exports = {
   ETH_TOKEN_ADDRESS: process.env.ETH_TOKEN_ADDRESS || '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
   INFURA_KEY: process.env.INFURA_KEY || '5771ac7556054b998e809aeadb16a31c',
   ENV: process.env.ENV || 'dev',
+  MAX_ALLOWANCE: process.env.MAX_ALLOWANCE || "115792089237316195423570985008687907853269984665640564039457584007913129639935",
 };

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,26 @@ class TokenSwap {
       ).address;
     }
     const refAddress = REF_ADDRESS;
+    const gasLimit = await getGasLimit(srcTokenAddress, dstTokenAddress, srcQty);
+    const gasPrice = await web3.eth.getGasPrice();
+    let gas = gasLimit * gasPrice;
+
+    gas = gas.toString();
+    const gasQtyEth = await web3.utils.fromWei(gas, 'ether');
+
+    const { balance } = await this.getTokenBalance(srcTokenAddress, userAdd);
+
+    if (srcTokenAddress === ETH_TOKEN_ADDRESS) {
+      if ((srcQty + gasQtyEth) > balance) {
+        return 'Insufficient Funds';
+      }
+    } else {
+      const userEthBalance = await this.getTokenBalance(ETH_TOKEN_ADDRESS, userAdd);
+
+      if ((userEthBalance < gasQtyEth) || (balance < srcQty)) {
+        return 'Insufficient Funds';
+      }
+    }
 
     if (srcTokenAddress !== ETH_TOKEN_ADDRESS) {
       const results = await this.getRates(srcTokenAddress, dstTokenAddress, srcQtyWei);

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const inblox = require('@inbloxme/keyless-transactions');
 
 const HELPER = require('./utils/helper');
 const {
-  kyberProxyContractAddress, KYBER_CURRENCY_URL, KYBER_GET_GAS_LIMIT_URL, REF_ADDRESS, ETH_TOKEN_ADDRESS, INFURA_KEY, ENV,
+  kyberProxyContractAddress, KYBER_CURRENCY_URL, KYBER_GET_GAS_LIMIT_URL, REF_ADDRESS, ETH_TOKEN_ADDRESS, INFURA_KEY, ENV, MAX_ALLOWANCE,
 } = require('./config');
 const { kyberProxyContractABI } = require('./constants/ABI/kyber-proxy-contract');
 const { erc20Contract } = require('./constants/ABI/erc20-contract');
@@ -76,7 +76,7 @@ class TokenSwap {
   }
 
   async swapTokens({
-    srcTokenAddress, dstTokenAddress, srcDecimal, srcQty, maxAllowance, privateKey, wallet, userAddress, userName, inbloxPassword,
+    srcTokenAddress, dstTokenAddress, srcDecimal, srcQty, privateKey, wallet, userAddress, userName, inbloxPassword,
   }) {
     const srcQtyWei = (srcQty * 10 ** srcDecimal).toString();
     let pvtKey;
@@ -104,7 +104,7 @@ class TokenSwap {
           srcQtyWei,
           dstTokenAddress,
           userAdd,
-          maxAllowance,
+          MAX_ALLOWANCE,
           results.slippageRate,
           refAddress,
           srcQty,
@@ -117,12 +117,12 @@ class TokenSwap {
 
         return txReceipt;
       }
-      await this.approveContract(maxAllowance, userAdd, srcTokenAddress, srcTokenContract, pvtKey, wallet);
+      await this.approveContract(MAX_ALLOWANCE, userAdd, srcTokenAddress, srcTokenContract, pvtKey, wallet);
       txReceipt = await this.trade(srcTokenAddress,
         srcQtyWei,
         dstTokenAddress,
         userAdd,
-        maxAllowance,
+        MAX_ALLOWANCE,
         results.slippageRate,
         refAddress,
         srcQty,
@@ -141,7 +141,7 @@ class TokenSwap {
       srcQtyWei,
       dstTokenAddress,
       userAdd,
-      maxAllowance,
+      MAX_ALLOWANCE,
       results.slippageRate,
       refAddress,
       srcQty,


### PR DESCRIPTION
Implemented check for insufficient funds in user wallet. If user wallet does not contain sufficient funds to carry out the token swap transaction 'Insufficient funds' error message is returned