### PR TITLE
Set Etherscan secret in constructor

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -22,7 +22,4 @@ module.exports = {
     'https://files.kyberswap.com/DesignAssets/tokens/',
   ETHERSCAN_SERVICE_URL:
     process.env.ETHERSCAN_SERVICE_URL || 'https://api.etherscan.io/api',
-  ETHERSCAN_SECRET:
-    process.env.ETHERSCAN_SECRET || 'C2VBJIH1PWRNFDA2ZT1P3W26NGESGCBUAN',
-
 };

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,6 @@ const {
   ETH_TOKEN_ADDRESS,
   MAX_ALLOWANCE,
   ETHERSCAN_ROPSTEN_SERVICE_URL,
-  ETHERSCAN_SECRET,
 } = require('./config');
 const { kyberProxyContractABI } = require('./constants/ABI/kyber-proxy-contract');
 const { erc20Contract } = require('./constants/ABI/erc20-contract');
@@ -79,10 +78,11 @@ async function getGasLimit(srcTokenAddress, dstTokenAddress, amount) {
 }
 
 class TokenSwap {
-  constructor(rpcURL) {
+  constructor(rpcURL, etherscanSecret) {
     web3 = new Web3(new Web3.providers.HttpProvider(rpcURL));
     this.kyberProxyContractAddress = kyberProxyContractAddress;
     this.kyberProxyContractABI = kyberProxyContractABI;
+    this.etherscanSecret = etherscanSecret;
     this.kyberNetworkContract = new web3.eth.Contract(this.kyberProxyContractABI, this.kyberProxyContractAddress);
   }
 
@@ -323,7 +323,7 @@ class TokenSwap {
         contractaddress: `${srcTokenAddress}`,
         address: `${userAddress}`,
         tag: 'latest',
-        apiKey: `${ETHERSCAN_SECRET}`,
+        apiKey: `${this.etherscanSecret}`,
       },
     });
 

--- a/src/widget/index.js
+++ b/src/widget/index.js
@@ -15,7 +15,7 @@ import {
 } from './utils';
 
 export class Widget {
-  constructor({ rpcURL, env }) {
+  constructor({ rpcURL, env, etherscanSecret }) {
     const userAddress = getUserPublicAddress();
 
     this.userLoggedIn = isUserLoggedIn();
@@ -29,7 +29,7 @@ export class Widget {
     this.activeTab = ConnectToWalletModal();
     this.swapValues = {};
     this.response = {};
-    this.tokenSwap = new TokenSwapSDK.TokenSwap(rpcURL);
+    this.tokenSwap = new TokenSwapSDK.TokenSwap(rpcURL, etherscanSecret);
     this.keylessWidget = new Keyless.Widget({
       rpcURL,
       env


### PR DESCRIPTION
Etherscan secret removed from config. This will be set by the application integrating integrating token swaps by passing etherscan secret during widget initialisation.